### PR TITLE
fix: TESS schedule ingestion needs bandpass unit

### DIFF
--- a/across_data_ingestion/tasks/schedules/tess/low_fidelity_planned.py
+++ b/across_data_ingestion/tasks/schedules/tess/low_fidelity_planned.py
@@ -11,9 +11,9 @@ logger = logging.getLogger("uvicorn.error")
 
 SECONDS_IN_A_WEEK = 60 * 60 * 24 * 7
 TESS_BANDPASS = {
-    "min": 5820,
-    "max": 11080,
-    "peak_wavelength": 8580,
+    "min": 6000,
+    "max": 10000,
+    "peak_wavelength": 7865,
     "unit": "angstrom",
     "filter_name": "TESS_red",
 }

--- a/tests/tasks/schedules/tess/mocks/orbit_observations/ACROSS_schedule_output.json
+++ b/tests/tasks/schedules/tess/mocks/orbit_observations/ACROSS_schedule_output.json
@@ -26,9 +26,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                  "min": 5820,
-                  "max": 11080,
-                  "peak_wavelength": 8580,
+                  "min": 6000,
+                  "max": 10000,
+                  "peak_wavelength": 7865,
                   "unit": "angstrom",
                   "filter_name": "TESS_red"
               }
@@ -50,9 +50,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
             }
@@ -74,9 +74,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }
@@ -98,9 +98,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }
@@ -134,9 +134,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }
@@ -158,9 +158,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }
@@ -182,9 +182,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }
@@ -206,9 +206,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }

--- a/tests/tasks/schedules/tess/mocks/placeholder_observations/ACROSS_schedule_output.json
+++ b/tests/tasks/schedules/tess/mocks/placeholder_observations/ACROSS_schedule_output.json
@@ -26,9 +26,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }
@@ -62,9 +62,9 @@
               "status": "planned",
               "type": "imaging",
               "bandpass": {
-                "min": 5820,
-                "max": 11080,
-                "peak_wavelength": 8580,
+                "min": 6000,
+                "max": 10000,
+                "peak_wavelength": 7865,
                 "unit": "angstrom",
                 "filter_name": "TESS_red"
               }


### PR DESCRIPTION
### Description

This PR fixes the TESS schedule ingestion. It adds a unit to the bandpass package.

### Related Issue(s)

https://github.com/ACROSS-Team/across-data-ingestion/issues/28

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

TESS schedules is submitted.
Tests are successful

### Testing

1. in across-server: `make dev` and then get local token for `dev@nasa.gov` (leave server running)
2. in across-data-ingestion: put the token in the `.env` file
3. in across-data-ingestion: `make dev` successfully ingests TESS schedule
