### PR TITLE
task: add across-server API calls to fermi schedule ingestion

### DIFF
--- a/across_data_ingestion/tasks/schedules/fermi/lat_planned.py
+++ b/across_data_ingestion/tasks/schedules/fermi/lat_planned.py
@@ -14,7 +14,7 @@ from fastapi_utils.tasks import repeat_every
 
 from ....core.constants import SECONDS_IN_A_WEEK
 
-# from ....util import across_api # TODO: Uncomment when integrating with server
+from ....util import across_api
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -175,14 +175,11 @@ def ingest() -> list | None:
     current_fermi_week = int(np.floor((Time(now).jd - FERMI_JD_WEEK_23) / 7 + 23))
 
     # GET Telescope by name
-    # TODO: Add Fermi observatory migration to server and uncomment the following lines
-    # fermi_telescope_info = across_api.telescope.get({"name": "fermi_lat"})[0]
-    # telescope_id = fermi_telescope_info["id"]
-    # instrument_id = fermi_telescope_info["instruments"][0]["id"]
-
-    # For now they're hardcoded
-    telescope_id = "fermi_lat_telescope_uuid"
-    instrument_id = "fermi_lat_instrument_uuid"
+    lat_telescope_info = across_api.telescope.get({"name": "lat"})[0]
+    telescope_id = lat_telescope_info["id"]
+    for instrument in lat_telescope_info["instruments"]:
+        if instrument["name"] == "Large Area Telescope":
+            instrument_id = instrument["id"]
 
     # Initialize list of schedules to append
     schedules = []
@@ -229,7 +226,7 @@ def ingest() -> list | None:
             observations.append(observation)
 
         schedule["observations"] = observations
-        logger.info(schedule)  # TODO: POST to the API endpoint
+        across_api.schedule.post(schedule)
         schedules.append(schedule)
 
     return schedules

--- a/tests/tasks/schedules/fermi/lat_planned_test.py
+++ b/tests/tasks/schedules/fermi/lat_planned_test.py
@@ -47,7 +47,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -81,7 +86,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -113,7 +123,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -190,7 +205,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -219,7 +239,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -241,7 +266,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -268,7 +298,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(
@@ -301,7 +336,12 @@ class TestFermiLATPlannedScheduleIngestionTask:
             return_value=[
                 {
                     "id": "fermi_lat_telescope_uuid",
-                    "instruments": [{"id": "fermi_lat_instrument_uuid"}],
+                    "instruments": [
+                        {
+                            "id": "fermi_lat_instrument_uuid",
+                            "name": "Large Area Telescope",
+                        }
+                    ],
                 }
             ],
         ), patch(


### PR DESCRIPTION
### Description

Adds GET `/telescope` and POST `/schedule` calls to the Fermi LAT schedule ingestion task to retrieve the required telescope and instrument IDs and post the schedule to `across-server`.

### Related Issue(s)

Resolves #33 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. Should request Fermi LAT `id` from across-server by using `GET /telescope` using telescope name `LAT` to search
2. Should submit a list of schedules and their associated observations to across-server via `POST /schedule` 
3. Should not log schedules at the end of the ingestion process

### Testing

1. Run the server with `make dev` and authenticate locally with dev@nasa.gov
2. Paste the response body in the `ACROSS_INGESTION_SERVICE_ACCOUNT_KEY` variable in `.env`
3. Run the ingestion tasks with `make dev`
4. Verify that the Fermi LAT ingestion task completes successfully
5. In the server, verify that Fermi LAT schedules were ingested
6. Verify unit tests pass