### PR TITLE
refactor: add v1 for across api access

### DIFF
--- a/across_data_ingestion/core/config.py
+++ b/across_data_ingestion/core/config.py
@@ -32,7 +32,7 @@ class Config(BaseConfig):
         return f"{self.HOST}:{self.PORT}{self.ROOT_PATH}"
 
     def across_server_url(self):
-        return f"{self.ACROSS_SERVER_HOST}:{self.ACROSS_SERVER_PORT}/{self.ACROSS_SERVER_ROOT_PATH}/{self.ACROSS_SERVER_VERSION}"
+        return f"{self.ACROSS_SERVER_HOST}:{self.ACROSS_SERVER_PORT}{self.ACROSS_SERVER_ROOT_PATH}{self.ACROSS_SERVER_VERSION}"
 
 
 config = Config()

--- a/across_data_ingestion/util/across_api/schedule/api.py
+++ b/across_data_ingestion/util/across_api/schedule/api.py
@@ -7,7 +7,7 @@ from ....core.exceptions import AcrossHTTPException  # type: ignore[import-untyp
 
 logger = logging.getLogger("uvicorn.error")
 
-SCHEDULE_URL: str = f"{config.across_server_url()}/schedule"
+SCHEDULE_URL: str = f"{config.across_server_url()}/schedule/"
 
 
 def post(data: dict = {}) -> None:

--- a/across_data_ingestion/util/across_api/telescope/api.py
+++ b/across_data_ingestion/util/across_api/telescope/api.py
@@ -5,7 +5,7 @@ import httpx
 from ....core.config import config  # type: ignore[import-untyped]
 from ....core.exceptions import AcrossHTTPException  # type: ignore[import-untyped]
 
-TELESCOPE_URL: str = f"{config.across_server_url()}/telescope"
+TELESCOPE_URL: str = f"{config.across_server_url()}/telescope/"
 
 
 def get(params: dict = {}) -> list[dict]:


### PR DESCRIPTION
### Description

Add across server version.

 - separate across server url into components, and build it.

### Related Issue(s)

Resolves #32

### Reviewers
@ACROSS-Team/developers 

### Acceptance Criteria

1. should access the across server v1 api.

### Testing

1. run the [API versioning branch](https://github.com/ACROSS-Team/across-server/pull/260).
2. execute a schedule ingestion; should make a call to telescope endpoint and post to schedule.
