### PR TITLE
fix: release-please PR merge triggers release-please action

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -1,0 +1,30 @@
+# Run this workflow only on merged release-please PRs
+name: Release PR Merged
+on:
+  push:
+    branches: ["main"]
+    # look for the specific files that are changed in a release-pr
+    paths:
+      - CHANGELOG.md
+      - across_server/__init__.py
+      - .release-please-manifest.json
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  deployments: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  release-please:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## description

1. Merge to main -> build -> deploy -> generate release PR :white_check_mark:
2. Merge release PR to main -> wasn't triggering merge to main workflow since it was ignoring changed files from release PR. 

Expected, but now need a separate workflow just for release PR merge, this PR adds the workflow.