### PR TITLE
fix(release): release-please needs ci

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -38,6 +38,7 @@ jobs:
         ${{ secrets.OPENAPI_SDK_SSH_KEY }}
 
   release-please:
+    needs: [ci]
     runs-on: "ubuntu-latest"
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
fix(release): release-please needs ci

this workflow will pass, but promote will run prematurely and fail, this prevents that.