### PR TITLE
fix: set seeded service account client credentials when running locally

### DIFF
--- a/across_data_ingestion/util/across_server/api_client_wrapper.py
+++ b/across_data_ingestion/util/across_server/api_client_wrapper.py
@@ -4,7 +4,14 @@ from across.sdk.v1.api_client_wrapper import ApiClientWrapper
 from ...core import config
 from .ssm_credentials import SSMCredentials
 
+sdk_config = sdk.Configuration(host=config.ACROSS_SERVER_URL)
+
+# use local dev service account
+if config.is_local():
+    sdk_config.username = config.ACROSS_SERVER_ID
+    sdk_config.password = config.ACROSS_SERVER_SECRET
+
 client = ApiClientWrapper.get_client(
-    configuration=sdk.Configuration(host=config.ACROSS_SERVER_URL),
+    configuration=sdk_config,
     creds=SSMCredentials() if not config.is_local() else None,
 )


### PR DESCRIPTION
### Description

This PR fixes a regression for running data ingestion locally against a local server with a seeded system service account.

### Related Issue(s)

Resolves #89 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

When running locally, seeded service account client credentials are automatically set

### Testing

1. run the across-server (preferably with a hard_reset or without any schedules or observations)
2. modify task_loader.py to comment out all but one task (for example TESS)
3. modify the task above to comment out the cron `repeat_at` so it launches instantly
4. run across-data-ingestion `make dev`
5. you should see a successful task completion with schedules posted to the locally running across-server
