### PR TITLE
fix: add http/https if missing, set check_server cron to every 30 mins

### DIFF
--- a/across_data_ingestion/core/config.py
+++ b/across_data_ingestion/core/config.py
@@ -37,7 +37,13 @@ class Config(BaseConfig):
 
     @property
     def ACROSS_SERVER_URL(self):
-        return f"{self.ACROSS_SERVER_HOST}:{self.ACROSS_SERVER_PORT}{self.ACROSS_SERVER_ROOT_PATH}{self.ACROSS_SERVER_VERSION}"
+        url = f"{self.ACROSS_SERVER_HOST}:{self.ACROSS_SERVER_PORT}{self.ACROSS_SERVER_ROOT_PATH}{self.ACROSS_SERVER_VERSION}"
+
+        # add protocol if DNE
+        if not url.startswith(("http://", "https://")):
+            url = f"http://{url}"
+
+        return url
 
     def is_local(self):
         return self.RUNTIME_ENV == Environments.LOCAL

--- a/across_data_ingestion/tasks/example/check_server.py
+++ b/across_data_ingestion/tasks/example/check_server.py
@@ -6,7 +6,7 @@ from ...util.across_server import client, sdk
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 
-@repeat_at(cron="30 * * * *", logger=logger)
+@repeat_at(cron="0,30 * * * *", logger=logger)
 async def check_server():
     observatories = sdk.ObservatoryApi(client).get_observatories()
 


### PR DESCRIPTION
## description

fix: add http/https if missing, set check_server cron to every 30 mins

 - service-connect needs http/https as part of the domain
 - check server should run as a health every 0 and 30 mins