### PR TITLE
fix: use TelescopeInstrument schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "Abell",
     "ASGI",
     "astropy",
     "astroquery",
@@ -29,10 +30,15 @@
     "isot",
     "ivoa",
     "ixpe",
+    "jwst",
     "LETG",
     "LIVETIME",
     "MCILWAIN",
+    "miri",
     "mypy",
+    "nircam",
+    "NIRISS",
+    "NIRSPEC",
     "NPOLE",
     "NUMASTER",
     "nustar",

--- a/across_data_ingestion/tasks/schedules/chandra/high_fidelity_planned.py
+++ b/across_data_ingestion/tasks/schedules/chandra/high_fidelity_planned.py
@@ -75,8 +75,8 @@ CHANDRA_TAP_URL = "https://cda.cfa.harvard.edu/cxctap/async"
 
 
 def match_instrument_from_tap_observation(
-    instruments_by_short_name: dict[str, sdk.IDNameSchema], tap_obs: Row
-) -> sdk.IDNameSchema:
+    instruments_by_short_name: dict[str, sdk.TelescopeInstrument], tap_obs: Row
+) -> sdk.TelescopeInstrument:
     """
     Constructs the instrument name from the observation parameters and
     returns both the name and the instrument id in across-server
@@ -104,7 +104,9 @@ def match_instrument_from_tap_observation(
             "Could not parse observation parameters for correct instrument",
             tap_observation=tap_obs,
         )
-        return sdk.IDNameSchema(id="", name="", short_name=None)
+        return sdk.TelescopeInstrument(
+            id="", name="", short_name="", created_on=datetime.now()
+        )
 
     return instruments_by_short_name[short_name]
 
@@ -191,7 +193,7 @@ async def get_observation_data_from_tap() -> Table:
 
 
 def transform_to_observation(
-    tap_obs: Row, instrument: sdk.IDNameSchema
+    tap_obs: Row, instrument: sdk.TelescopeInstrument
 ) -> sdk.ObservationCreate:
     begin = tap_obs["start_date"]
     end = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,10 +96,11 @@ def fake_telescope() -> sdk.Telescope:
         name="Test Telescope",
         short_name="tt",
         instruments=[
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="test-instrument-id",
                 name="Test Instrument",
                 short_name="ti",
+                created_on=datetime.now(),
             )
         ],
     )
@@ -131,8 +132,13 @@ def fake_observatory() -> sdk.Observatory:
         name="Treedome Space Observatory",
         short_name="MT",
         type=sdk.ObservatoryType.SPACE_BASED,
+        reference_url=None,
         telescopes=[
-            sdk.IDNameSchema(id="uuid", name="Treedome Telescope", short_name="tree")
+            sdk.IDNameSchema(
+                id="uuid",
+                name="Treedome Telescope",
+                short_name="tree",
+            )
         ],
         ephemeris_types=[
             sdk.ObservatoryEphemerisType(

--- a/tests/tasks/schedules/chandra/conftest.py
+++ b/tests/tasks/schedules/chandra/conftest.py
@@ -24,10 +24,11 @@ def fake_telescope() -> sdk.Telescope:
         short_name="chandra",
         created_on=datetime.now(),
         instruments=[
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="instrument_uuid",
                 name="CHANDRA ACIS",
                 short_name="ACIS",
+                created_on=datetime.now(),
             )
         ],
     )
@@ -121,57 +122,65 @@ def mock_vo_service_cls(mock_vo_service: AsyncMock) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def fake_instruments() -> list[sdk.IDNameSchema]:
+def fake_instruments() -> list[sdk.TelescopeInstrument]:
     instruments = [
         {
             "name": "Instrument Name - ACIS",
             "short_name": "ACIS",
             "id": "acis-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - ACIS-HETG",
             "short_name": "ACIS-HETG",
             "id": "acis-hetg-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - ACIS-LETG",
             "short_name": "ACIS-LETG",
             "id": "acis-letg-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - ACIS-CC",
             "short_name": "ACIS-CC",
             "id": "acis-cc-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - HRC",
             "short_name": "HRC",
             "id": "hrc-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - HRC-HETG",
             "short_name": "HRC-HETG",
             "id": "hrc-hetg-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - HRC-LETG",
             "short_name": "HRC-LETG",
             "id": "hrc-letg-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
         {
             "name": "Instrument Name - HRC-Timing",
             "short_name": "HRC-Timing",
             "id": "hrc-timing-mock-id",
+            "created_on": "2025-10-09 00:00:00",
         },
     ]
 
-    return [sdk.IDNameSchema(**info) for info in instruments]
+    return [sdk.TelescopeInstrument.model_validate(info) for info in instruments]
 
 
 @pytest.fixture
 def fake_instruments_by_short_name(
-    fake_instruments: list[sdk.IDNameSchema],
-) -> dict[str, sdk.IDNameSchema]:
+    fake_instruments: list[sdk.TelescopeInstrument],
+) -> dict[str, sdk.TelescopeInstrument]:
     return {
         (instrument.short_name or ""): instrument for instrument in fake_instruments
     }

--- a/tests/tasks/schedules/chandra/high_fidelity_planned_test.py
+++ b/tests/tasks/schedules/chandra/high_fidelity_planned_test.py
@@ -67,23 +67,23 @@ class TestChandraHighFidelityPlannedScheduleIngestionTask:
             ),
             (
                 {"instrument": "ACIS", "grating": "BAD_GRATING", "exposure_mode": ""},
-                None,
+                "",
             ),
             (
                 {"instrument": "HRC", "grating": "BAD_GRATING", "exposure_mode": ""},
-                None,
+                "",
             ),
             (
                 {"instrument": "BAD_INSTRUMENT", "grating": "", "exposure_mode": ""},
-                None,
+                "",
             ),
         ],
     )
     def test_should_match_instrument_from_tap_observation(
         self,
         mock_tap_row: dict,
-        expected_instrument_short_name: tuple,
-        fake_instruments_by_short_name: dict[str, sdk.IDNameSchema],
+        expected_instrument_short_name: str,
+        fake_instruments_by_short_name: dict[str, sdk.TelescopeInstrument],
     ) -> None:
         """Should return correct instrument name and id from observation row"""
         instrument = match_instrument_from_tap_observation(

--- a/tests/tasks/schedules/fermi/conftest.py
+++ b/tests/tasks/schedules/fermi/conftest.py
@@ -263,10 +263,11 @@ def fake_fermi_telescope() -> sdk.Telescope:
         short_name="fermi_lat",
         created_on=datetime.now(),
         instruments=[
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="fermi_lat_instrument_uuid",
                 name="Large Area Telescope",
                 short_name="LAT",
+                created_on=datetime.now(),
             )
         ],
     )

--- a/tests/tasks/schedules/hst/conftest.py
+++ b/tests/tasks/schedules/hst/conftest.py
@@ -144,10 +144,11 @@ def fake_telescope() -> sdk.Telescope:
         short_name="hst",
         created_on=datetime.now(),
         instruments=[
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="instrument_uuid",
                 name="Wide Field Camera 3 - Infrared Channel",
                 short_name="HST_WFC3_IR",
+                created_on=datetime.now(),
             )
         ],
     )

--- a/tests/tasks/schedules/jwst/conftest.py
+++ b/tests/tasks/schedules/jwst/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +13,6 @@ from across_data_ingestion.util.across_server import sdk
 def set_telescope(
     mock_telescope_api: MagicMock,
     fake_jwst_telescope: sdk.Telescope,
-    mock_instrument_api: MagicMock,
 ) -> None:
     mock_telescope_api.get_telescopes.return_value = [fake_jwst_telescope]
 
@@ -31,7 +31,7 @@ def mock_logger() -> Generator[MagicMock]:
 ## FAKE DATA ##
 @pytest.fixture
 def fake_jwst_telescope(
-    fake_telescope: sdk.Telescope, fake_jwst_instruments: list[sdk.IDNameSchema]
+    fake_telescope: sdk.Telescope, fake_jwst_instruments: list[sdk.TelescopeInstrument]
 ) -> sdk.Telescope:
     fake_telescope.id = "jwst_telescope_id"
 
@@ -41,42 +41,30 @@ def fake_jwst_telescope(
 
 
 @pytest.fixture
-def fake_jwst_instruments() -> list[sdk.IDNameSchema]:
+def fake_jwst_instruments() -> list[sdk.TelescopeInstrument]:
     return [
-        sdk.IDNameSchema(
+        sdk.TelescopeInstrument(
             id="miri_instrument_id",
             name="MIRI",
             short_name="JWST_MIRI",
+            created_on=datetime.now(),
         ),
-        sdk.IDNameSchema(
+        sdk.TelescopeInstrument(
             id="nircam_instrument_id",
             name="NIRCAM",
             short_name="JWST_NIRCAM",
+            created_on=datetime.now(),
         ),
-        sdk.IDNameSchema(
+        sdk.TelescopeInstrument(
             id="niriss_instrument_id",
             name="NIRISS",
             short_name="JWST_NIRISS",
+            created_on=datetime.now(),
         ),
-        sdk.IDNameSchema(
+        sdk.TelescopeInstrument(
             id="nirspec_instrument_id",
             name="NIRSPEC",
             short_name="JWST_NIRSPEC",
+            created_on=datetime.now(),
         ),
     ]
-
-
-# @pytest.fixture
-# def fake_create_many_schedules(
-#     fake_tess_telescope: sdk.Telescope,
-# ) -> dict[str, sdk.ScheduleCreateMany]:
-#     return {
-#         "placeholder_observations": sdk.ScheduleCreateMany(
-#             schedules=mocks.placeholder_observations.ACROSS_schedule_output.expected,
-#             telescope_id=fake_tess_telescope.id,
-#         ),
-#         "orbit_observations": sdk.ScheduleCreateMany(
-#             schedules=mocks.orbit_observations.ACROSS_schedule_output.expected,
-#             telescope_id=fake_tess_telescope.id,
-#         ),
-#     }

--- a/tests/tasks/schedules/xmm_newton/conftest.py
+++ b/tests/tasks/schedules/xmm_newton/conftest.py
@@ -38,25 +38,29 @@ def fake_telescope() -> sdk.Telescope:
         short_name="XMM-Newton",
         created_on=datetime.now(),
         instruments=[
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="epic-mos_instrument_uuid",
                 name="European Photon Imaging Camera - MOS",
                 short_name="EPIC-MOS",
+                created_on=datetime.now(),
             ),
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="epic-pn_instrument_uuid",
                 name="European Photon Imaging Camera - pn",
                 short_name="EPIC-PN",
+                created_on=datetime.now(),
             ),
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="rgs_instrument_uuid",
                 name="Reflection Grating Spectrometer",
                 short_name="RGS",
+                created_on=datetime.now(),
             ),
-            sdk.IDNameSchema(
+            sdk.TelescopeInstrument(
                 id="om_instrument_uuid",
                 name="Optical Monitor",
                 short_name="OM",
+                created_on=datetime.now(),
             ),
         ],
     )


### PR DESCRIPTION
### Description

A change was made to conditionally add data which change the interface of telescope to include instrument data. this changed from `IdNameSchema`

when the sdk was updated, this caused a cascade of test and type failures.

This resolves those type and test errors

### Related Issue(s)

N/a

### Reviewers

### Acceptance Criteria

types and test passes

### Testing

N/A CI will pass
