### PR TITLE
feat(TLE): add spacetrack config, load user/pwd from aws ssm in deployed env

### DIFF
--- a/across_data_ingestion/core/config.py
+++ b/across_data_ingestion/core/config.py
@@ -27,9 +27,6 @@ class Config(BaseConfig):
     AWS_REGION: str = "us-east-2"
     AWS_PROFILE: str | None = None
 
-    SPACETRACK_USER: str = "spacetrack-username"
-    SPACETRACK_PWD: str = "spacetrack-pwd"
-
     # Logging
     LOG_LEVEL: str = "DEBUG"
     # Adjusts the output being rendered as JSON (False for dev with pretty-print).

--- a/across_data_ingestion/tasks/tles/config.py
+++ b/across_data_ingestion/tasks/tles/config.py
@@ -1,0 +1,31 @@
+import structlog
+
+from ...core.config import BaseConfig
+from ...core.config import config as core_config
+from ...util.ssm import SSM
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger()
+
+
+class Config(BaseConfig):
+    SPACETRACK_USER: str = "spacetrack-username"
+    SPACETRACK_PWD: str = "spacetrack-pwd"
+
+    def __init__(self) -> None:
+        super().__init__()
+        if not core_config.is_local():
+            logger.debug("Getting spacetrack credentials from SSM...")
+
+            self.SPACETRACK_USER = str(
+                SSM.get_parameter("spacetrack/username", core_config.APP_ENV)
+            )
+            self.SPACETRACK_PWD = str(
+                SSM.get_parameter("spacetrack/password", core_config.APP_ENV)
+            )
+
+            logger.debug("Retrieved spacetrack credentials from SSM!")
+        else:
+            logger.debug("Local spacetrack credentials loaded")
+
+
+spacetrack_config = Config()

--- a/across_data_ingestion/tasks/tles/tle_ingestion.py
+++ b/across_data_ingestion/tasks/tles/tle_ingestion.py
@@ -5,8 +5,8 @@ import structlog
 from across.tools import tle as tle_tool
 from fastapi_utilities import repeat_at  # type: ignore
 
-from ...core import config
 from ...util.across_server import client, sdk
+from .config import spacetrack_config
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
@@ -63,8 +63,8 @@ def ingest() -> None:
         tle = tle_tool.get_tle(
             norad_id=satellite.id,
             epoch=datetime.now(),
-            spacetrack_user=config.SPACETRACK_USER,
-            spacetrack_pwd=config.SPACETRACK_PWD,
+            spacetrack_user=spacetrack_config.SPACETRACK_USER,
+            spacetrack_pwd=spacetrack_config.SPACETRACK_PWD,
         )
 
         if tle:
@@ -93,7 +93,7 @@ def ingest() -> None:
             logger.warning("Could not fetch TLE", satellite=satellite.model_dump())
 
 
-@repeat_at(cron="34 4 * * *", logger=logger)
+@repeat_at(cron="34 4,16 * * *", logger=logger)
 async def entrypoint() -> None:
     try:
         ingest()

--- a/requirements/action.txt
+++ b/requirements/action.txt
@@ -57,8 +57,6 @@ certifi==2024.8.30
     #   httpx
     #   requests
     #   skyfield
-cffi==2.0.0
-    # via cryptography
 cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.2
@@ -71,8 +69,6 @@ coverage==7.6.9
     # via pytest-cov
 croniter==1.4.1
     # via fastapi-utilities
-cryptography==46.0.2
-    # via secretstorage
 distlib==0.3.9
     # via virtualenv
 dnspython==2.7.0
@@ -95,8 +91,6 @@ filelock==3.16.1
     # via virtualenv
 geoalchemy2==0.15.2
     # via -r requirements/base.in
-greenlet==3.2.4
-    # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
@@ -130,10 +124,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.2.1
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jmespath==1.0.1
     # via
     #   boto3
@@ -199,8 +189,6 @@ pyasn1==0.6.1
     # via
     #   python-jose
     #   rsa
-pycparser==2.23
-    # via cffi
 pydantic==2.10.3
     # via
     #   across-server-openapi-python
@@ -266,8 +254,6 @@ rush==2021.4.0
     # via spacetrack
 s3transfer==0.10.4
     # via boto3
-secretstorage==3.4.0
-    # via keyring
 sgp4==2.23
     # via
     #   -r requirements/base.in

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -55,8 +55,6 @@ certifi==2024.8.30
     #   httpx
     #   requests
     #   skyfield
-cffi==2.0.0
-    # via cryptography
 charset-normalizer==3.4.2
     # via requests
 click==8.1.7
@@ -65,8 +63,6 @@ click-spinner==0.1.10
     # via fastapi-utilities
 croniter==1.4.1
     # via fastapi-utilities
-cryptography==46.0.2
-    # via secretstorage
 dnspython==2.7.0
     # via email-validator
 ecdsa==0.19.1
@@ -84,8 +80,6 @@ fastapi-utils==0.8.0
     # via -r requirements/base.in
 geoalchemy2==0.15.2
     # via -r requirements/base.in
-greenlet==3.2.4
-    # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
@@ -117,10 +111,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.2.1
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jmespath==1.0.1
     # via
     #   boto3
@@ -175,8 +165,6 @@ pyasn1==0.6.1
     # via
     #   python-jose
     #   rsa
-pycparser==2.23
-    # via cffi
 pydantic==2.10.2
     # via
     #   across-server-openapi-python
@@ -230,8 +218,6 @@ rush==2021.4.0
     # via spacetrack
 s3transfer==0.10.4
     # via boto3
-secretstorage==3.4.0
-    # via keyring
 sgp4==2.23
     # via
     #   -r requirements/base.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -58,8 +58,6 @@ certifi==2024.8.30
     #   httpx
     #   requests
     #   skyfield
-cffi==2.0.0
-    # via cryptography
 cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.2
@@ -74,8 +72,6 @@ coverage==7.6.8
     # via pytest-cov
 croniter==1.4.1
     # via fastapi-utilities
-cryptography==46.0.2
-    # via secretstorage
 distlib==0.3.9
     # via virtualenv
 dnspython==2.7.0
@@ -103,8 +99,6 @@ filelock==3.16.1
     # via virtualenv
 geoalchemy2==0.15.2
     # via -r requirements/base.in
-greenlet==3.2.4
-    # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
@@ -141,10 +135,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via fastapi
 jmespath==1.0.1
@@ -218,8 +208,6 @@ pyasn1==0.6.1
     # via
     #   python-jose
     #   rsa
-pycparser==2.23
-    # via cffi
 pydantic==2.10.2
     # via
     #   across-server-openapi-python
@@ -294,8 +282,6 @@ rush==2021.4.0
     # via spacetrack
 s3transfer==0.10.4
     # via boto3
-secretstorage==3.4.0
-    # via keyring
 sgp4==2.23
     # via
     #   -r requirements/base.in


### PR DESCRIPTION
### Description

This PR modifies how we load SPACETRACK_USER and SPACETRACK_PWD to enable fetching credentials from AWS SSM in deployed environments.

This PR also doubles the cadence of fetching TLEs to twice every 24 hours

### Related Issue(s)

Resolves #53 
Depends on SSM keys existing in infrastructure repo https://github.com/ACROSS-Team/across-infrastructure/issues/41
   - ✅ parameters created and values populated in AWS
### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. local credentials should continue to load from `.env`
2. deployed environments should load spacetrack credentials from SSM

### Testing

1. Run locally to ensure local .env credentials are still loaded
2. run against `dev` using the debugger or deploy to dev to verify SSM loads correctly and TLEs are ingested
