### PR TITLE
fix: tle config properly sets space-track credentials

### DIFF
--- a/across_data_ingestion/tasks/tles/config.py
+++ b/across_data_ingestion/tasks/tles/config.py
@@ -16,12 +16,17 @@ class Config(BaseConfig):
         if not core_config.is_local():
             logger.debug("Getting spacetrack credentials from SSM...")
 
-            self.SPACETRACK_USER = str(
-                SSM.get_parameter("spacetrack/username", core_config.APP_ENV)
+            user_param = SSM.get_parameter("spacetrack/username", core_config.APP_ENV)
+            self.SPACETRACK_USER = str(user_param.get("Value"))
+
+            logger.debug(
+                "Loaded spacetrack username from SSM", username=self.SPACETRACK_USER
             )
-            self.SPACETRACK_PWD = str(
-                SSM.get_parameter("spacetrack/password", core_config.APP_ENV)
+
+            password_param = SSM.get_parameter(
+                "spacetrack/password", core_config.APP_ENV
             )
+            self.SPACETRACK_PWD = str(password_param.get("Value"))
 
             logger.debug("Retrieved spacetrack credentials from SSM!")
         else:


### PR DESCRIPTION
### Description

This PR fixes setting space-track credentials from SSM in aws deployed environments

### Related Issue(s)

Resolves #97 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. TLE ingestion should authenticate successfully following SSM credential retrieval

### Testing

1. place debuggers in `across_data_ingestion/tasks/tles/config.py` following each credential being set to verify
2. login with aws sso `aws configure sso`
3. run against dev
4. you should see that the credentials are loaded and set properly in the logs
<img width="882" height="81" alt="image" src="https://github.com/user-attachments/assets/2ece4e07-f8bf-40df-a441-1115bffc0f8e" />

