### PR TITLE
chore: increase check_server frequency for debugging

### DIFF
--- a/across_data_ingestion/tasks/example/check_server.py
+++ b/across_data_ingestion/tasks/example/check_server.py
@@ -6,7 +6,7 @@ from ...util.across_server import client, sdk
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 
-@repeat_at(cron="0,30 * * * *", logger=logger)
+@repeat_at(cron="*/5 * * * *", logger=logger)
 async def check_server():
     observatories = sdk.ObservatoryApi(client).get_observatories()
 


### PR DESCRIPTION
### Description

increase check_server frequency to every 5 mins for debugging

### Related Issue(s)

Resolves #99 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

When deployed, check_server should run every 5 mins to aid in debugging

### Testing

N/A
