### PR TITLE
fix: change TESS schedule to run every tuesday at 10:12pm

### DIFF
--- a/across_data_ingestion/tasks/schedules/tess/low_fidelity_planned.py
+++ b/across_data_ingestion/tasks/schedules/tess/low_fidelity_planned.py
@@ -191,7 +191,7 @@ def ingest():
     return schedules
 
 
-@repeat_at(cron="12 22 * * 2", logger=logger)
+@repeat_at(cron="12 5 * * 3", logger=logger)
 async def entrypoint():
     try:
         logger.info("Schedule ingestion started.")


### PR DESCRIPTION
### Description

Updates the tess schedule to run every Tuesday at 10:12 pm

### Related Issue(s)

#114 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

The TESS schedule is available before the demo... talk

### Testing

the cron expression is correct.
