### PR TITLE
fix: fermi observation type is slew

### DIFF
--- a/across_data_ingestion/tasks/schedules/fermi/lat_planned.py
+++ b/across_data_ingestion/tasks/schedules/fermi/lat_planned.py
@@ -279,7 +279,7 @@ def transform_to_observations(
             date_range=sdk.DateRange(begin=row.BEGIN, end=row.END),  # type:ignore
             external_observation_id=row.OBS_NAME,  # type:ignore
             exposure_time=row.EXPOSURE,  # type:ignore
-            type=sdk.ObservationType.IMAGING,
+            type=sdk.ObservationType.SLEW,
             status=sdk.ObservationStatus.PLANNED,
             pointing_angle=FERMI_LAT_POINTING_ANGLE,
             bandpass=sdk.Bandpass(

--- a/tests/tasks/schedules/fermi/conftest.py
+++ b/tests/tasks/schedules/fermi/conftest.py
@@ -214,7 +214,7 @@ def fake_observation_create(
             end=datetime.fromisoformat("2025-3-5T23:59:55"),
         ),
         external_observation_id=f"fermi_week_{fake_fermi_week}_observation_0",
-        type=sdk.ObservationType.IMAGING,
+        type=sdk.ObservationType.SLEW,
         status=sdk.ObservationStatus.PLANNED,
         pointing_angle=FERMI_LAT_POINTING_ANGLE,
         exposure_time=float(60),

--- a/tests/tasks/schedules/fermi/mocks/mock_final_schedule_output.json
+++ b/tests/tasks/schedules/fermi/mocks/mock_final_schedule_output.json
@@ -21,7 +21,7 @@
                     "end": "2025-03-05T23:59:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_0",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -45,7 +45,7 @@
                     "end": "2025-03-06T00:00:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_1",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -69,7 +69,7 @@
                     "end": "2025-03-06T00:01:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_2",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -93,7 +93,7 @@
                     "end": "2025-03-06T00:02:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_3",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -117,7 +117,7 @@
                     "end": "2025-03-06T00:03:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_4",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -141,7 +141,7 @@
                     "end": "2025-03-06T00:04:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_5",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -165,7 +165,7 @@
                     "end": "2025-03-06T00:05:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_6",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -189,7 +189,7 @@
                     "end": "2025-03-06T00:06:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_7",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -213,7 +213,7 @@
                     "end": "2025-03-06T00:07:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_8",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -237,7 +237,7 @@
                     "end": "2025-03-06T00:08:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_9",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,

--- a/tests/tasks/schedules/fermi/mocks/mock_prelim_schedule_output.json
+++ b/tests/tasks/schedules/fermi/mocks/mock_prelim_schedule_output.json
@@ -21,7 +21,7 @@
                     "end": "2025-03-05T23:59:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_0",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -45,7 +45,7 @@
                     "end": "2025-03-06T00:00:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_1",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -69,7 +69,7 @@
                     "end": "2025-03-06T00:01:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_2",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -93,7 +93,7 @@
                     "end": "2025-03-06T00:02:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_3",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -117,7 +117,7 @@
                     "end": "2025-03-06T00:03:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_4",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -141,7 +141,7 @@
                     "end": "2025-03-06T00:04:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_5",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -165,7 +165,7 @@
                     "end": "2025-03-06T00:05:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_6",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -189,7 +189,7 @@
                     "end": "2025-03-06T00:06:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_7",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -213,7 +213,7 @@
                     "end": "2025-03-06T00:07:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_8",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,
@@ -237,7 +237,7 @@
                     "end": "2025-03-06T00:08:55.000"
                 },
                 "external_observation_id": "fermi_week_878_observation_9",
-                "type": "imaging",
+                "type": "slew",
                 "status": "planned",
                 "pointing_angle": 0,
                 "exposure_time": 60.0,


### PR DESCRIPTION
### Description

Changes the fermi-lat observations' `observation.type` from `IMAGING` to `SLEW` types. 

### Related Issue(s)

#179 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

Observations are submitted to the server as slew types

### Testing

Tests still pass and local ingestion confirms slew type observations exist
