### PR TITLE
fix: fix broken IXPE low fidelity planned schedule ingestion

### DIFF
--- a/across_data_ingestion/tasks/schedules/ixpe/low_fidelity_planned.py
+++ b/across_data_ingestion/tasks/schedules/ixpe/low_fidelity_planned.py
@@ -19,40 +19,57 @@ IXPE_BANDPASS = sdk.EnergyBandpass(
     filter_name="IXPE",
 )
 
+EXPECTED_TABLE_COLUMNS = ["Start", "Name", "RA", "Dec"]
+
 
 def query_ixpe_schedule() -> pd.DataFrame:
     # Send a GET request to the webpage
-    response = httpx.get(IXPE_LTP_URL)
-    response.raise_for_status()
+
+    try:
+        response = httpx.get(IXPE_LTP_URL)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.error(
+            "Long term planned schedule request failed",
+            error=str(exc),
+        )
+        return pd.DataFrame()
 
     try:
         # Parse the webpage content with BeautifulSoup
         soup = bs4.BeautifulSoup(response.text, "html.parser")
 
-        # Extract schedule information (adjust selectors based on the webpage structure)
-        schedule_table = soup.find("table")  # Assuming the schedule is in a table
-        schedule_data = []
+        # Fetch all HTML tables to search for schedule
+        tables_to_search = soup.find_all("table")
 
-        if schedule_table:
-            rows = schedule_table.find_all("tr")  # type: ignore
-            for row in rows:
-                columns = row.find_all("td")
-                schedule_data.append([col.get_text(strip=True) for col in columns])
+        if tables_to_search:
+            for table in tables_to_search:
+                schedule_data = []
+                rows = table.find_all("tr")  # type: ignore
+                for row in rows:
+                    columns = row.find_all("td")
+                    schedule_data.append([col.get_text(strip=True) for col in columns])
 
-            # Convert to a pandas dataframe with header information
-            header = schedule_data.pop(0)
+                # Convert to a pandas dataframe with header information
+                header = schedule_data.pop(0)
 
-            ixpe_df = pd.DataFrame(schedule_data, columns=header)
+                if all([column in header for column in EXPECTED_TABLE_COLUMNS]):
+                    # We found the table with the schedule data
+                    ixpe_df = pd.DataFrame(schedule_data, columns=header)
 
-            # IXPE doesn't give an end time for these schedules
-            # Populate them with the next observations start time.
-            # The last target won't have an end time, so fill it with its start time
-            ixpe_df["Start"] = pd.to_datetime(ixpe_df["Start"])
-            ixpe_df["Stop"] = ixpe_df["Start"].shift(-1).fillna(ixpe_df["Start"])
-            ixpe_df["Start"] = ixpe_df["Start"].astype(str)
-            ixpe_df["Stop"] = ixpe_df["Stop"].astype(str)
+                    # IXPE doesn't give an end time for these schedules
+                    # Populate them with the next observations start time.
+                    # The last target won't have an end time, so fill it with its start time
+                    ixpe_df["Start"] = pd.to_datetime(ixpe_df["Start"])
+                    ixpe_df["Stop"] = (
+                        ixpe_df["Start"].shift(-1).fillna(ixpe_df["Start"])
+                    )
+                    ixpe_df["Start"] = ixpe_df["Start"].astype(str)
+                    ixpe_df["Stop"] = ixpe_df["Stop"].astype(str)
 
-            return ixpe_df
+                    return ixpe_df
+
+        logger.warning("Could not find correct schedule table to read")
 
     except Exception as e:
         logger.error(

--- a/tests/tasks/schedules/ixpe/conftest.py
+++ b/tests/tasks/schedules/ixpe/conftest.py
@@ -10,7 +10,7 @@ from .mocks import mock_ixpe_query, sample_html_string
 
 
 ## SET DATA FROM TOP-LEVEL FIXTURES ##
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def set_mock_res_text(fake_httpx_response: MagicMock) -> None:
     fake_httpx_response.text = sample_html_string.html
 

--- a/tests/tasks/schedules/ixpe/low_fidelity_planned_test.py
+++ b/tests/tasks/schedules/ixpe/low_fidelity_planned_test.py
@@ -13,7 +13,7 @@ from across_data_ingestion.tasks.schedules.ixpe.low_fidelity_planned import (
 from across_data_ingestion.util import across_server
 
 
-class TestNicerLowFidelityScheduleIngestionTask:
+class TestIxpeLowFidelityScheduleIngestionTask:
     class TestIngest:
         @pytest.fixture(autouse=True)
         def patch_query_ixpe_schedule(
@@ -42,7 +42,7 @@ class TestNicerLowFidelityScheduleIngestionTask:
             assert isinstance(args[0], across_server.sdk.ScheduleCreate)
 
         def test_should_call_get_telescopes(self, mock_telescope_api: MagicMock):
-            """Should create ACROSS schedules"""
+            """Should call get telescopes"""
             ingest()
             mock_telescope_api.get_telescopes.assert_called()
 
@@ -76,22 +76,29 @@ class TestNicerLowFidelityScheduleIngestionTask:
             data = query_ixpe_schedule()
             assert not len(data)
 
-        def test_should_raise_error_when_status_is_failure(
-            self, mock_httpx_get: MagicMock
+        def test_should_log_warning_when_status_is_failure(
+            self,
+            mock_httpx_get: MagicMock,
+            mock_logger: MagicMock,
         ):
+            """Should trap exception and log warning when httpx request fails"""
             fake_error_res = httpx.Response(
                 status_code=400, request=httpx.Request("GET", "http://test.com")
             )
             mock_httpx_get.return_value = fake_error_res
 
-            with pytest.raises(httpx.HTTPStatusError):
-                query_ixpe_schedule()
+            query_ixpe_schedule()
+            assert (
+                "Long term planned schedule request failed"
+                in mock_logger.error.call_args[0]
+            )
 
         def test_should_log_error_when_parsing_fails(
             self, monkeypatch: pytest.MonkeyPatch, mock_logger: MagicMock
         ):
+            """Should log error when BeautifulSoup throws error"""
             mock_soup_instance = MagicMock(spec=bs4.BeautifulSoup)
-            mock_soup_instance.find.side_effect = Exception("oh no")
+            mock_soup_instance.find_all.side_effect = Exception("oh no")
             mock_soup_cls = MagicMock(return_value=mock_soup_instance)
 
             monkeypatch.setattr(bs4, "BeautifulSoup", mock_soup_cls)
@@ -99,3 +106,17 @@ class TestNicerLowFidelityScheduleIngestionTask:
             query_ixpe_schedule()
 
             mock_logger.error.assert_called_once()
+
+        def test_should_log_warning_when_cannot_find_correct_table(
+            self,
+            mock_logger: MagicMock,
+            fake_httpx_response: MagicMock,
+        ) -> None:
+            """Should log warning when cannot find a table with long term planend schedule"""
+            fake_httpx_response.text = "<table><tr><td></td></tr></table>"
+
+            query_ixpe_schedule()
+            assert (
+                "Could not find correct schedule table to read"
+                in mock_logger.warning.call_args[0]
+            )

--- a/tests/tasks/schedules/ixpe/mocks/sample_html_string.py
+++ b/tests/tasks/schedules/ixpe/mocks/sample_html_string.py
@@ -84,6 +84,17 @@ At such time, the LTP will be adjusted, attempting to minimize the
 impact on the overall plan; however, nothing is guaranteed.
 </P>
 
+<table style="BORDER:0; margin:auto;">
+
+<tbody><tr>
+ <td style="width:40px">Prop</td>
+ <td style="width:120px">Name</td>
+ <td style="width:64px">RA</td>
+ <td style="width:56px">Dec</td>
+</tr>
+<tr><td>2142  </td><td>SS 433      </td><td> 287.9565</td><td>  4.98272</td></tr>
+</tbody></table>
+
 <P>
 IXPE is telemetry limited for bright sources and this requires that
 observations be handled slightly differently from the way most X-ray


### PR DESCRIPTION
### Description

This PR fixes the broken IXPE low fidelity planned schedule ingestion task. A new irrelevant HTML table was added to the long term planned schedule [page](https://ixpe.msfc.nasa.gov/for_scientists/ltp.html) which broke the ingestion task. This is because the task assumed that the first returned table contained the schedule information, and when trying to extract observation parameters by column name, was getting a `KeyError` as the table did not contain the required columns. Now the ingestion will verify that the table has the expected columns before attempting to scrape its rows. 

### Related Issue(s)

Resolves #220 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. IXPE low fidelity planned schedule ingestion should work as expected

### Testing

1. Comment the `repeat_at` decorator and run the ingestion task locally with a server running
2. Verify the long term planned schedule is ingested as expected