### PR TITLE
feat(config): remove api root path prefix to support new domain

### DIFF
--- a/across_data_ingestion/core/config.py
+++ b/across_data_ingestion/core/config.py
@@ -12,11 +12,11 @@ class Config(BaseConfig):
     RUNTIME_ENV: Environments = Environments.LOCAL
     HOST: str = "localhost"
     PORT: int = 8001
-    ROOT_PATH: str = "/api"
+    ROOT_PATH: str = ""
 
     ACROSS_SERVER_HOST: str = "http://localhost"
     ACROSS_SERVER_PORT: int = 8000
-    ACROSS_SERVER_ROOT_PATH: str = "/api"
+    ACROSS_SERVER_ROOT_PATH: str = ""
     ACROSS_SERVER_VERSION: str = "/v1"
 
     ACROSS_SERVER_ID: str = "9798d4e2-fe46-4da9-8708-dd098c27ea8c"

--- a/scripts/create_env_file.py
+++ b/scripts/create_env_file.py
@@ -6,7 +6,7 @@ def create_env_file():
 
     env_vars = {
         "ACROSS_INGESTION_SERVICE_ACCOUNT_KEY": "local-service-account-key",
-        "ACROSS_SERVER_URL": "http://localhost:8000/api/v1/",
+        "ACROSS_SERVER_URL": "http://localhost:8000/v1/",
         "ACROSS_DEBUG": True,
     }
 


### PR DESCRIPTION
### Description

This PR adjusts the config to remove the root path prefix /api to support the new api server domain name

### Related Issue(s)

Resolves #245

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. data ingestion should continue to function as expected.

### Testing

1. pull the server companion PR https://github.com/NASA-ACROSS/across-server/pull/585
2. checkout this PR and disable all tasks in `task_loader.py` other than `check_server`
3. run data ingestion with `make dev` and ensure that the `check_server` request succeeds


