### PR TITLE
fix: use spacetrack recommended method for ingesting latest tles

### DIFF
--- a/across_data_ingestion/tasks/tles/tle_ingestion.py
+++ b/across_data_ingestion/tasks/tles/tle_ingestion.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import TypedDict
 
 import structlog
@@ -62,7 +61,6 @@ def ingest() -> None:
     # query spacetrack for all satellites and parse out the newest result for each norad_id
     tles = tle_tool.get_tle(
         satellites=satellites,
-        epoch=datetime.now(),
         spacetrack_user=spacetrack_config.SPACETRACK_USER,
         spacetrack_pwd=spacetrack_config.SPACETRACK_PWD,
         spacetrack_base_url=spacetrack_config.SPACETRACK_BASE_URL,
@@ -96,7 +94,6 @@ def ingest() -> None:
                         "TLE Already Exists",
                         name=across_tle.satellite_name,
                         norad_id=across_tle.norad_id,
-                        epoch=satellite_tle.epoch,
                     )
                 else:
                     raise err

--- a/requirements/action.txt
+++ b/requirements/action.txt
@@ -2,7 +2,7 @@
 #    uv pip compile requirements/action.in -o requirements/action.txt
 across-server-openapi-python==1.2.0
     # via -r requirements/base.in
-across-tools==1.5.0
+across-tools==1.6.1
     # via -r requirements/base.in
 alembic==1.18.1
     # via -r requirements/base.in
@@ -39,7 +39,9 @@ asyncer==0.0.12
 asyncpg==0.31.0
     # via -r requirements/base.in
 attrs==25.4.0
-    # via rush
+    # via
+    #   outcome
+    #   rush
 beautifulsoup4==4.14.3
     # via
     #   -r requirements/base.in
@@ -199,7 +201,9 @@ pandas-stubs==2.3.3.260113
 pathspec==0.12.1
     # via mypy
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   spacetrack
+    #   virtualenv
 plotly==6.7.0
     # via across-tools
 pluggy==1.6.0
@@ -308,7 +312,7 @@ sqlalchemy==2.0.49
     #   alembic
     #   fastapi-utilities
     #   geoalchemy2
-starlette==1.0.0
+starlette==0.50.0
     # via fastapi
 structlog==25.5.0
     # via -r requirements/base.in
@@ -358,7 +362,6 @@ typing-inspect==0.9.0
     # via -r requirements/base.in
 typing-inspection==0.4.2
     # via
-    #   fastapi
     #   pydantic
     #   pydantic-settings
 urllib3==2.6.3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core dependencies
 
-across-tools >= 1.5.0
+across-tools >= 1.6.1
 across-server-openapi-python >= 1.1.1
 alembic >=1.13.2,<2
 asyncer >=0.0.8,<0.0.13

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -2,7 +2,7 @@
 #    uv pip compile requirements/deploy.in -o requirements/deploy.txt
 across-server-openapi-python==1.2.0
     # via -r requirements/base.in
-across-tools==1.5.0
+across-tools==1.6.1
     # via -r requirements/base.in
 alembic==1.18.1
     # via -r requirements/base.in
@@ -39,7 +39,9 @@ asyncer==0.0.12
 asyncpg==0.31.0
     # via -r requirements/base.in
 attrs==25.4.0
-    # via rush
+    # via
+    #   outcome
+    #   rush
 beautifulsoup4==4.14.3
     # via
     #   -r requirements/base.in
@@ -83,6 +85,8 @@ fastapi-utilities==0.3.1
     # via -r requirements/base.in
 fastapi-utils==0.8.0
     # via -r requirements/base.in
+filelock==3.29.0
+    # via spacetrack
 geoalchemy2==0.18.1
     # via -r requirements/base.in
 h11==0.16.0
@@ -172,6 +176,8 @@ pandas==3.0.2
     #   swifttools
 pandas-stubs==2.3.3.260113
     # via -r requirements/base.in
+platformdirs==4.9.6
+    # via spacetrack
 plotly==6.7.0
     # via across-tools
 pluggy==1.6.0
@@ -262,7 +268,7 @@ sqlalchemy==2.0.49
     #   alembic
     #   fastapi-utilities
     #   geoalchemy2
-starlette==1.0.0
+starlette==0.50.0
     # via fastapi
 structlog==25.5.0
     # via -r requirements/base.in
@@ -272,6 +278,8 @@ tabulate==0.9.0
     # via swifttools
 tqdm==4.67.3
     # via swifttools
+types-pytz==2026.2.0.20260506
+    # via pandas-stubs
 typing-extensions==4.15.0
     # via
     #   across-server-openapi-python
@@ -291,7 +299,6 @@ typing-inspect==0.9.0
     # via -r requirements/base.in
 typing-inspection==0.4.2
     # via
-    #   fastapi
     #   pydantic
     #   pydantic-settings
 urllib3==2.6.3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 #    uv pip compile requirements/local.in -o requirements/local.txt
 across-server-openapi-python==1.2.0
     # via -r requirements/base.in
-across-tools==1.5.0
+across-tools==1.6.1
     # via -r requirements/base.in
 alembic==1.18.1
     # via -r requirements/base.in
@@ -42,7 +42,9 @@ asyncer==0.0.12
 asyncpg==0.31.0
     # via -r requirements/base.in
 attrs==25.4.0
-    # via rush
+    # via
+    #   outcome
+    #   rush
 beautifulsoup4==4.14.3
     # via
     #   -r requirements/base.in
@@ -228,7 +230,9 @@ pandas-stubs==2.3.3.260113
 pathspec==0.12.1
     # via mypy
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   spacetrack
+    #   virtualenv
 plotly==6.7.0
     # via across-tools
 pluggy==1.6.0


### PR DESCRIPTION
### Description

Use spacetrack recommended URL for ingesting latest TLEs

### Related Issue(s)

Resolves #253

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. tle ingestion runs with one request to spacetrack

### Testing

1. pull branch
2. comment out task loader other than tle ingestion
3. comment out tle ingestion cron
4. make dev
5. :tada:
<img width="876" height="208" alt="image" src="https://github.com/user-attachments/assets/e9672871-3ac9-4a49-be62-b3a36d6ed55f" />
