### PR TITLE
feat: add xrism planned schedule ingestion task

### DIFF
--- a/across_data_ingestion/tasks/schedules/xrism/constants.py
+++ b/across_data_ingestion/tasks/schedules/xrism/constants.py
@@ -1,0 +1,22 @@
+from ....util.across_server import sdk
+
+XRISM_BANDPASSES = {
+    "Resolve": sdk.EnergyBandpass(
+        filter_name="XRISM Resolve",
+        min=1.7,
+        max=12.0,
+        unit=sdk.EnergyUnit.KEV,
+    ),
+    "Xtend": sdk.EnergyBandpass(
+        filter_name="XRISM Xtend",
+        min=0.4,
+        max=13.0,
+        unit=sdk.EnergyUnit.KEV,
+    ),
+}
+
+
+XRISM_OBSERVATION_TYPES = {
+    "Resolve": sdk.ObservationType.SPECTROSCOPY,
+    "Xtend": sdk.ObservationType.IMAGING,
+}

--- a/across_data_ingestion/tasks/schedules/xrism/handler.py
+++ b/across_data_ingestion/tasks/schedules/xrism/handler.py
@@ -13,7 +13,7 @@ logger: structlog.stdlib.BoundLogger = structlog.getLogger()
 
 
 class XRISMScheduleHandler:
-    """Handles the creation and posting of Euclid schedules to the ACROSS API."""
+    """Handles the creation and posting of XRISM schedules to the ACROSS API."""
 
     def __init__(
         self,

--- a/across_data_ingestion/tasks/schedules/xrism/handler.py
+++ b/across_data_ingestion/tasks/schedules/xrism/handler.py
@@ -1,0 +1,154 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import structlog
+from astropy.time import Time  # type: ignore[import-untyped]
+
+from ....util.across_server import client, sdk
+from ....util.footprint_util import project_footprint
+from .constants import XRISM_BANDPASSES, XRISM_OBSERVATION_TYPES
+
+logger: structlog.stdlib.BoundLogger = structlog.getLogger()
+
+
+class XRISMScheduleHandler:
+    """Handles the creation and posting of Euclid schedules to the ACROSS API."""
+
+    def __init__(
+        self,
+        observation_status: sdk.ObservationStatus,
+        schedule_status: sdk.ScheduleStatus,
+        schedule_fidelity: sdk.ScheduleFidelity,
+        schedule_name: str,
+    ):
+        self.observation_status = observation_status
+        self.schedule_status = schedule_status
+        self.schedule_fidelity = schedule_fidelity
+        self.schedule_name = schedule_name
+        self.telescope = sdk.TelescopeApi(client).get_telescopes(
+            name="X-ray Mirror Assembly", include_footprints=True
+        )[0]
+
+    def _create_xrism_observations(
+        self,
+        observation_df: pd.DataFrame,
+        observation_status: sdk.ObservationStatus,
+        instrument: sdk.TelescopeInstrument,
+    ) -> list[sdk.ObservationCreate]:
+        """
+        Creates ACROSS ObservationCreate objects for XRISM observations from
+        the short term schedule pandas DataFrame.
+        """
+        across_observations = []
+
+        for _, obs in observation_df.iterrows():
+            # Filter out calibration observations with NaN exposure times
+            if not np.isnan(obs.exposure_time):
+                footprint = None
+                if instrument.footprints:
+                    footprint = project_footprint(
+                        instrument.footprints,
+                        ra=float(obs.Ra),
+                        dec=float(obs.Dec),
+                        roll_angle=float(obs.roll_angle)
+                        if hasattr(obs, "roll_angle")
+                        else 0.0,
+                    )
+                across_observations.append(
+                    sdk.ObservationCreate(
+                        instrument_id=instrument.id,
+                        object_name=obs.TargetName,
+                        pointing_position=sdk.Coordinate(
+                            ra=float(obs.Ra),
+                            dec=float(obs.Dec),
+                        ),
+                        object_position=sdk.Coordinate(
+                            ra=float(obs.Ra),
+                            dec=float(obs.Dec),
+                        ),
+                        date_range=sdk.DateRange(
+                            begin=datetime.strptime(
+                                obs.start_time, "%Y-%m-%dT%H:%M:%S"
+                            ),
+                            end=datetime.strptime(obs.start_time, "%Y-%m-%dT%H:%M:%S")
+                            + timedelta(seconds=obs.exposure_time * 1000.0),
+                        ),
+                        external_observation_id=str(obs.observation_id),
+                        type=XRISM_OBSERVATION_TYPES.get(
+                            instrument.short_name, sdk.ObservationType.IMAGING
+                        ),
+                        status=observation_status,
+                        pointing_angle=float(obs.roll_angle)
+                        if hasattr(obs, "roll_angle")
+                        else 0.0,
+                        exposure_time=obs.exposure_time * 1000.0,
+                        bandpass=sdk.Bandpass(XRISM_BANDPASSES[instrument.short_name]),
+                        footprint=footprint,
+                    )
+                )
+
+        return across_observations
+
+    def _create_xrism_across_schedule(
+        self,
+        schedule_status: sdk.ScheduleStatus,
+        schedule_fidelity: sdk.ScheduleFidelity,
+        schedule_name: str,
+        observations: list[sdk.ObservationCreate],
+    ) -> sdk.ScheduleCreate:
+        """
+        Creates ACROSS ScheduleCreate object given
+        the status and fidelity of the schedule, the name of the schedule,
+        and a list of ObservationCreate objects.
+        """
+        begins = [obs.date_range.begin for obs in observations]
+        ends = [obs.date_range.end for obs in observations]
+
+        begin = Time(min(begins)).isot
+        end = Time(max(ends)).isot
+
+        return sdk.ScheduleCreate(
+            telescope_id=self.telescope.id,
+            name=f"XRISM_{schedule_name}_{begin.split('T')[0]}_{end.split('T')[0]}",
+            date_range=sdk.DateRange(
+                begin=begin,
+                end=end,
+            ),
+            status=schedule_status,
+            fidelity=schedule_fidelity,
+            observations=observations,
+        )
+
+    def run(self, observation_df: pd.DataFrame):
+        """
+        Run the schedule handler to create and post schedules and observations
+        to the ACROSS server, given a pandas DataFrame of observation information.
+        """
+        # Create observations for each instrument
+        xrism_obs = []
+        for instrument in self.telescope.instruments:  # type: ignore[union-attr]
+            xrism_obs += self._create_xrism_observations(
+                observation_df=observation_df,
+                observation_status=self.observation_status,
+                instrument=instrument,
+            )
+
+        # Create schedule containing all observations
+        euclid_schedule = self._create_xrism_across_schedule(
+            schedule_status=self.schedule_status,
+            schedule_fidelity=self.schedule_fidelity,
+            schedule_name=self.schedule_name,
+            observations=xrism_obs,
+        )
+
+        # Post the schedule to the ACROSS API
+        try:
+            sdk.ScheduleApi(client).create_schedule(euclid_schedule)
+        except sdk.ApiException as err:
+            if err.status == 409:
+                logger.info(
+                    "Schedule already exists.", schedule_name=euclid_schedule.name
+                )
+            else:
+                raise err

--- a/across_data_ingestion/tasks/schedules/xrism/handler.py
+++ b/across_data_ingestion/tasks/schedules/xrism/handler.py
@@ -135,7 +135,7 @@ class XRISMScheduleHandler:
             )
 
         # Create schedule containing all observations
-        euclid_schedule = self._create_xrism_across_schedule(
+        xrism_schedule = self._create_xrism_across_schedule(
             schedule_status=self.schedule_status,
             schedule_fidelity=self.schedule_fidelity,
             schedule_name=self.schedule_name,
@@ -144,11 +144,11 @@ class XRISMScheduleHandler:
 
         # Post the schedule to the ACROSS API
         try:
-            sdk.ScheduleApi(client).create_schedule(euclid_schedule)
+            sdk.ScheduleApi(client).create_schedule(xrism_schedule)
         except sdk.ApiException as err:
             if err.status == 409:
                 logger.info(
-                    "Schedule already exists.", schedule_name=euclid_schedule.name
+                    "Schedule already exists.", schedule_name=xrism_schedule.name
                 )
             else:
                 raise err

--- a/across_data_ingestion/tasks/schedules/xrism/low_fidelity_planned.py
+++ b/across_data_ingestion/tasks/schedules/xrism/low_fidelity_planned.py
@@ -1,0 +1,133 @@
+from urllib.parse import urlencode
+
+import numpy as np
+import pandas as pd
+import structlog
+from fastapi_utilities import repeat_at  # type: ignore
+
+from ....util.across_server import sdk
+from .handler import XRISMScheduleHandler
+
+logger: structlog.stdlib.BoundLogger = structlog.getLogger()
+
+
+XRISM_SHORT_TERM_SCHEDULE_URL = (
+    "https://xrism.isas.jaxa.jp/research/observers/shortterm/prefinal/index.html"
+)
+XRISM_TOO_TABLE_URL = (
+    "https://xrism.isas.jaxa.jp/research/observers/generic_too/index.html"
+)
+
+
+def parse_short_term_schedule_page() -> pd.DataFrame:
+    """
+    Parse the short term schedule page to extract the most recent
+    planned schedule table. Planned schedules are broken down by week,
+    so this function identifies the most recent schedule and parses
+    it into a pandas DataFrame.
+    """
+    short_term_schedules = pd.read_html(XRISM_SHORT_TERM_SCHEDULE_URL, flavor="bs4")
+    if len(short_term_schedules):
+        # The most recent schedule is the first table on the page
+        short_term_schedule = short_term_schedules[0]
+        short_term_schedule = short_term_schedule.rename(
+            columns={"Seq": "observation_id", "Mnv start time (UT)": "start_time"}
+        )
+        return short_term_schedule
+    logger.warning("Could not find any short term schedule tables to parse")
+    return pd.DataFrame([])
+
+
+def query_proposal_table(observation_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Query the XRISM database to extract exposure times from the proposal table
+    for the observation IDs in the short term schedule dataframe. This is necessary
+    because the short term schedule table does not contain exposure time info.
+    Adds the exposure time information to the short term schedule dataframe and returns it.
+    Skips over calibration observations (which have proposal type "CAL") by assigning them NaN exposure times.
+    """
+    observation_ids = observation_df["observation_id"].to_list()
+    query = f"SELECT * FROM xrism_proposal WHERE observation_id IN ({', '.join(f"'{obs_id}'" for obs_id in observation_ids)});"
+    xrism_query_url = (
+        "https://darts.isas.jaxa.jp/app/query/astroquery/sql.php?"
+        + urlencode(query={"sql": query})
+    )
+    proposal_dfs = pd.read_html(xrism_query_url, flavor="bs4")
+    if len(proposal_dfs):
+        proposal_df = proposal_dfs[0]
+        for _, row in observation_df.iterrows():
+            obs_id = row["observation_id"]
+            if obs_id in proposal_df["observation_id"].values:
+                proposal_row = proposal_df.loc[proposal_df["observation_id"] == obs_id]
+                if proposal_row["proposal_type"].values[0] != "CAL":
+                    exposure_time = proposal_row["awarded_exposure"].values[
+                        0
+                    ]  # in ksec
+                    observation_df.loc[
+                        observation_df["observation_id"] == obs_id, "exposure_time"
+                    ] = exposure_time
+                else:
+                    observation_df.loc[
+                        observation_df["observation_id"] == obs_id, "exposure_time"
+                    ] = np.nan
+
+    else:
+        logger.warning(
+            "Could not find exposure time information for short term schedule observations"
+        )
+
+    return observation_df
+
+
+def parse_too_table(observation_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Query the ToO page to retrieve exposure times for ToO observations.
+    ToO observations will not be in the XRISM proposal table, so this
+    function scrapes the ToO information and crossmatches on sequence ID (aka observation ID)
+    to add exposure time information to the short term schedule dataframe.
+    Returns a dataframe of the short term schedule with exposure times.
+    """
+    too_dfs = pd.read_html(XRISM_TOO_TABLE_URL, flavor="bs4")
+    if len(too_dfs):
+        too_df = too_dfs[0]
+    else:
+        logger.warning("Could not read ToO table")
+        return observation_df
+
+    for _, row in observation_df.iterrows():
+        obs_id = row["observation_id"]
+        if obs_id in too_df["Seq"].values:
+            exposure_time = too_df.loc[too_df["Seq"] == obs_id, "Exp. (ks)"].values[
+                0
+            ]  # In ksec
+            observation_df.loc[
+                observation_df["observation_id"] == obs_id, "exposure_time"
+            ] = exposure_time
+
+    return observation_df
+
+
+def ingest() -> None:
+    short_term_schedule_df = parse_short_term_schedule_page()
+    short_term_schedule_df = query_proposal_table(short_term_schedule_df)
+    short_term_schedule_df = parse_too_table(short_term_schedule_df)
+
+    handler = XRISMScheduleHandler(
+        observation_status=sdk.ObservationStatus.PLANNED,
+        schedule_status=sdk.ScheduleStatus.PLANNED,
+        schedule_fidelity=sdk.ScheduleFidelity.LOW,
+        schedule_name="low_fidelity_planned",
+    )
+    handler.run(short_term_schedule_df)
+
+
+@repeat_at(cron="5 4 * * 2,5", logger=logger)
+async def entrypoint():
+    try:
+        logger.info("Schedule ingestion started.")
+        ingest()
+        logger.info("Schedule ingestion completed.")
+        return
+    except Exception as e:
+        logger.error("Encountered an unknown error", err=e, exc_info=True)
+        return

--- a/across_data_ingestion/tasks/task_loader.py
+++ b/across_data_ingestion/tasks/task_loader.py
@@ -49,6 +49,9 @@ from .schedules.tess.low_fidelity_planned import (
 from .schedules.xmm_newton.low_fidelity_planned import (
     entrypoint as XMM_Newton_low_fidelity_schedule_ingestion_task,
 )
+from .schedules.xrism.low_fidelity_planned import (
+    entrypoint as XRISM_low_fidelity_schedule_ingestion_task,
+)
 from .tles.tle_ingestion import (
     entrypoint as tle_ingestion_task,
 )
@@ -78,3 +81,4 @@ async def init_tasks():
     create_task(rubin_low_fidelity_planned_schedule_ingestion_task())
     create_task(HST_as_flown_schedule_ingestion_task())
     create_task(euclid_low_fidelity_planned_schedule_ingestion_task())
+    create_task(XRISM_low_fidelity_schedule_ingestion_task())

--- a/tests/tasks/schedules/xrism/conftest.py
+++ b/tests/tasks/schedules/xrism/conftest.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+import structlog
+
+from across_data_ingestion.util.across_server import sdk
+
+
+@pytest.fixture(autouse=True)
+def mock_logger(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock = MagicMock(spec=structlog.stdlib.BoundLogger)
+    monkeypatch.setattr(
+        "across_data_ingestion.tasks.schedules.xrism.low_fidelity_planned.logger",
+        mock,
+    )
+
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def mock_pandas_html(
+    mock_pandas: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> MagicMock:
+    mock_pandas.read_html = MagicMock(return_value=[])
+    monkeypatch.setattr(pd, "read_html", mock_pandas.read_html)
+
+    return mock_pandas
+
+
+@pytest.fixture
+def fake_short_term_schedule_table() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Mnv start time (UT)": ["2026-06-04T02:21:00"],
+            "Seq": ["12345"],
+            "TargetName": ["Cygnus X-1"],
+            "Ra": [299.590],
+            "Dec": [35.201],
+        }
+    )
+
+
+@pytest.fixture
+def fake_xrism_proposal_table() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "observation_id": ["12345"],
+            "proposal_type": ["CAL"],
+            "awarded_exposure": [50],
+        }
+    )
+
+
+@pytest.fixture
+def fake_xrism_too_table() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Seq": ["12345"],
+            "Exp. (ks)": [50],
+        }
+    )
+
+
+@pytest.fixture
+def fake_observation_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "start_time": ["2026-06-04T02:21:00"],
+            "observation_id": ["12345"],
+            "TargetName": ["Cygnus X-1"],
+            "Ra": [299.590],
+            "Dec": [35.201],
+            "exposure_time": [50],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_schedule_handler(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_handler = MagicMock()
+    mock_handler.run = MagicMock(return_value=None)
+
+    mock = MagicMock(return_value=mock_handler)
+
+    monkeypatch.setattr(
+        "across_data_ingestion.tasks.schedules.xrism.low_fidelity_planned.XRISMScheduleHandler",
+        mock,
+    )
+
+    return mock_handler
+
+
+@pytest.fixture()
+def mock_parse_short_term_schedule_page(
+    fake_short_term_schedule_table: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> MagicMock:
+    mock = MagicMock(return_value=fake_short_term_schedule_table)
+    monkeypatch.setattr(
+        "across_data_ingestion.tasks.schedules.xrism.low_fidelity_planned.parse_short_term_schedule_page",
+        mock,
+    )
+
+    return mock
+
+
+@pytest.fixture()
+def mock_query_proposal_table(
+    fake_xrism_proposal_table: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> MagicMock:
+    mock = MagicMock(return_value=fake_xrism_proposal_table)
+    monkeypatch.setattr(
+        "across_data_ingestion.tasks.schedules.xrism.low_fidelity_planned.query_proposal_table",
+        mock,
+    )
+
+    return mock
+
+
+@pytest.fixture()
+def mock_parse_too_table(
+    fake_xrism_too_table: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> MagicMock:
+    mock = MagicMock(return_value=fake_xrism_too_table)
+    monkeypatch.setattr(
+        "across_data_ingestion.tasks.schedules.xrism.low_fidelity_planned.parse_too_table",
+        mock,
+    )
+
+    return mock
+
+
+@pytest.fixture()
+def fake_xrism_instrument() -> sdk.TelescopeInstrument:
+    return sdk.TelescopeInstrument(
+        id="resolve_instrument_uuid",
+        name="Resolve",
+        short_name="Resolve",
+        created_on=datetime.now(),
+        footprints=[],
+    )
+
+
+@pytest.fixture
+def fake_xrism_telescope(
+    fake_xrism_instrument: sdk.TelescopeInstrument,
+) -> sdk.Telescope:
+    return sdk.Telescope(
+        id="xma_telescope_id",
+        created_on=datetime.now(),
+        name="XMA",
+        short_name="XMA",
+        instruments=[fake_xrism_instrument],
+    )

--- a/tests/tasks/schedules/xrism/handler_test.py
+++ b/tests/tasks/schedules/xrism/handler_test.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from across_data_ingestion.tasks.schedules.xrism.handler import XRISMScheduleHandler
+from across_data_ingestion.util.across_server import sdk
+
+from .mocks.mock_xrism_observations import mock_xrism_observations
+
+
+class TestXRISMScheduleHandler:
+    class TestCreateXRISMObservations:
+        @pytest.mark.parametrize("field", sdk.ObservationCreate.model_fields)
+        def test_should_create_observations_with_expected_parameters(
+            self,
+            fake_observation_df: pd.DataFrame,
+            fake_xrism_instrument: sdk.TelescopeInstrument,
+            field: str,
+        ) -> None:
+            """Should extract correct parameters from input DataFrame"""
+            handler = XRISMScheduleHandler(
+                observation_status=sdk.ObservationStatus.PLANNED,
+                schedule_status=sdk.ScheduleStatus.PLANNED,
+                schedule_name="low_fidelity_planned",
+                schedule_fidelity=sdk.ScheduleFidelity.LOW,
+            )
+            created_observations = handler._create_xrism_observations(
+                observation_df=fake_observation_df,
+                observation_status=sdk.ObservationStatus.PLANNED,
+                instrument=fake_xrism_instrument,
+            )
+            expected_obs = sdk.ObservationCreate.model_validate(
+                mock_xrism_observations[0]
+            )
+            assert getattr(created_observations[0], field) == getattr(
+                expected_obs, field
+            )
+
+    class TestCreateXRISMAcrossSchedule:
+        def test_should_create_schedule(self) -> None:
+            """Should create ACROSS schedule"""
+            mock_observations = [
+                sdk.ObservationCreate.model_validate(mock_xrism_observations[0])
+            ]
+            handler = XRISMScheduleHandler(
+                observation_status=sdk.ObservationStatus.PLANNED,
+                schedule_status=sdk.ScheduleStatus.PLANNED,
+                schedule_name="low_fidelity_planned",
+                schedule_fidelity=sdk.ScheduleFidelity.LOW,
+            )
+            created_schedule = handler._create_xrism_across_schedule(
+                schedule_status=sdk.ScheduleStatus.PLANNED,
+                schedule_fidelity=sdk.ScheduleFidelity.LOW,
+                schedule_name="low_fidelity_planned",
+                observations=mock_observations,
+            )
+
+            assert isinstance(created_schedule, sdk.ScheduleCreate)
+
+    class TestRun:
+        def test_should_call_create_schedule(
+            self,
+            mock_telescope_api: MagicMock,
+            mock_schedule_api: MagicMock,
+            fake_observation_df: pd.DataFrame,
+            fake_xrism_telescope: sdk.Telescope,
+        ) -> None:
+            """Should call create schedule on run"""
+            mock_telescope_api.get_telescopes.return_value = [fake_xrism_telescope]
+            handler = XRISMScheduleHandler(
+                observation_status=sdk.ObservationStatus.PLANNED,
+                schedule_status=sdk.ScheduleStatus.PLANNED,
+                schedule_name="low_fidelity_planned",
+                schedule_fidelity=sdk.ScheduleFidelity.LOW,
+            )
+            handler.run(fake_observation_df)
+            mock_schedule_api.create_schedule.assert_called_once()

--- a/tests/tasks/schedules/xrism/low_fidelity_planned_test.py
+++ b/tests/tasks/schedules/xrism/low_fidelity_planned_test.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+
+from across_data_ingestion.tasks.schedules.xrism.low_fidelity_planned import (
+    ingest,
+    parse_short_term_schedule_page,
+    parse_too_table,
+    query_proposal_table,
+)
+
+
+class TestParseShortTermSchedulePage:
+    def test_should_log_warning_if_no_schedules_found(
+        self,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Should log a warning if no schedule tables are found on the short term schedule page"""
+        parse_short_term_schedule_page()
+        assert (
+            "Could not find any short term schedule tables to parse"
+            in mock_logger.warning.call_args[0][0]
+        )
+
+    def test_should_return_empty_df_if_no_schedules_found(
+        self,
+    ) -> None:
+        """Should return an empty DataFrame if no schedule tables are found on the short term schedule page"""
+        df = parse_short_term_schedule_page()
+        assert len(df) == 0
+
+    def test_should_return_df_if_schedules_found(
+        self,
+        mock_pandas_html: MagicMock,
+        fake_short_term_schedule_table: pd.DataFrame,
+    ) -> None:
+        """Should return a DataFrame of the first schedule table found on the short term schedule page"""
+        mock_pandas_html.read_html.return_value = [fake_short_term_schedule_table]
+        df = parse_short_term_schedule_page()
+        assert len(df)
+
+
+class TestQueryProposalTable:
+    def test_should_log_warning_if_no_results_found(
+        self, mock_logger: MagicMock
+    ) -> None:
+        """Should log a warning if no results are found from the XRISM proposal table query"""
+        query_proposal_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert (
+            "Could not find exposure time information for short term schedule observations"
+            in mock_logger.warning.call_args[0][0]
+        )
+
+    def test_should_add_exposure_times_from_query_results(
+        self,
+        mock_pandas_html: MagicMock,
+        fake_xrism_proposal_table: pd.DataFrame,
+    ) -> None:
+        """Should add exposure times from results of the XRISM proposal table query"""
+        fake_xrism_proposal_table["proposal_type"] = "GO"
+        mock_pandas_html.read_html.return_value = [fake_xrism_proposal_table]
+        df = query_proposal_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert (
+            df["exposure_time"].values
+            == fake_xrism_proposal_table["awarded_exposure"].values
+        )
+
+    def test_should_not_add_exposure_times_for_calibration_observations(
+        self,
+        mock_pandas_html: MagicMock,
+        fake_xrism_proposal_table: pd.DataFrame,
+    ) -> None:
+        """Should not add exposure times for calibration observations"""
+        mock_pandas_html.read_html.return_value = [fake_xrism_proposal_table]
+        df = query_proposal_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert all(np.isnan(df["exposure_time"]).values)
+
+    def test_should_return_dataframe_with_same_observation_ids(
+        self,
+        mock_pandas_html: MagicMock,
+        fake_xrism_proposal_table: pd.DataFrame,
+    ) -> None:
+        """Should return a dataframe with the same observation IDs as the input"""
+        mock_pandas_html.read_html.return_value = [fake_xrism_proposal_table]
+        df = query_proposal_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert df["observation_id"].values == ["12345"]
+
+
+class TestParseToOTable:
+    def test_should_log_warning_if_no_tables_found(
+        self, mock_logger: MagicMock
+    ) -> None:
+        """Should log a warning if no tables are found on the ToO page"""
+        parse_too_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert "Could not read ToO table" in mock_logger.warning.call_args[0][0]
+
+    def test_should_add_exposure_times_from_query_results(
+        self,
+        mock_pandas_html: MagicMock,
+        fake_xrism_too_table: pd.DataFrame,
+    ) -> None:
+        """Should add exposure times from the ToO page"""
+        mock_pandas_html.read_html.return_value = [fake_xrism_too_table]
+        df = parse_too_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert df["exposure_time"].values == fake_xrism_too_table["Exp. (ks)"].values
+
+    def test_should_return_dataframe_with_same_observation_ids(
+        self,
+        mock_pandas_html: MagicMock,
+        fake_xrism_too_table: pd.DataFrame,
+    ) -> None:
+        """Should return a dataframe with the same observation IDs as the input"""
+        fake_xrism_too_table.loc[0] = {"Seq": "54321", "Exp. (ks)": 50000}
+        mock_pandas_html.read_html.return_value = [fake_xrism_too_table]
+        df = parse_too_table(pd.DataFrame({"observation_id": ["12345"]}))
+        assert df["observation_id"].values == ["12345"]
+
+
+class TestIngest:
+    def test_should_call_schedule_handler(
+        self,
+        mock_schedule_handler: MagicMock,
+        mock_parse_short_term_schedule_page: MagicMock,
+        mock_query_proposal_table: MagicMock,
+        mock_parse_too_table: MagicMock,
+    ) -> None:
+        """Should call the schedule handler to handle the observations once"""
+        ingest()
+
+        mock_schedule_handler.run.assert_called_once()

--- a/tests/tasks/schedules/xrism/mocks/mock_xrism_observations.py
+++ b/tests/tasks/schedules/xrism/mocks/mock_xrism_observations.py
@@ -1,0 +1,37 @@
+import datetime
+
+from across_data_ingestion.util.across_server import sdk
+
+mock_xrism_observations: list[dict] = [
+    {
+        "instrument_id": "resolve_instrument_uuid",
+        "object_name": "Cygnus X-1",
+        "pointing_position": {
+            "ra": 299.590,
+            "dec": 35.201,
+        },
+        "object_position": {
+            "ra": 299.590,
+            "dec": 35.201,
+        },
+        "date_range": {
+            "begin": datetime.datetime(2026, 6, 4, 2, 21, 0),
+            "end": datetime.datetime(2026, 6, 4, 16, 14, 20),
+        },
+        "external_observation_id": "12345",
+        "type": "spectroscopy",
+        "status": "planned",
+        "pointing_angle": 0.0,
+        "exposure_time": 50000,
+        "bandpass": sdk.Bandpass(
+            sdk.EnergyBandpass.model_validate(
+                {
+                    "filter_name": "XRISM Resolve",
+                    "min": 1.7,
+                    "max": 12.0,
+                    "unit": sdk.EnergyUnit.KEV,
+                }
+            )
+        ),
+    },
+]


### PR DESCRIPTION
### Description

This PR adds the XRISM low fidelity planned schedule ingestion task. Planned targets for the upcoming week are read from the XRISM [short term schedule page](https://xrism.isas.jaxa.jp/research/observers/shortterm/prefinal/index.html) and crossmatched with both the XRISM proposal database and ToO pages to aggregate exposure times. Observations are created for both the Resolve and Xtend instruments. This runs every Friday (a few hours after the schedule is historically uploaded to the short term schedule page) and Tuesday (to search for any modifications) to the schedule.

### Related Issue(s)

Resolves #200

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. Should ingest XRISM planned observations into the ACROSS core-server
2. Should log info when successful
3. Should log errors when failing

### Testing

1. Run your local server
2. Comment out the `repeat_at` decorator for this task and run `make dev`
3. Verify observations are ingested into the server
4. Verify observation and schedule data looks correct